### PR TITLE
BNetServer issue with clients connecting without launcher 

### DIFF
--- a/Source/Framework/Networking/SSLSocket.cs
+++ b/Source/Framework/Networking/SSLSocket.cs
@@ -67,6 +67,8 @@ namespace Framework.Networking
             try
             {
                 var result = await _stream.ReadAsync(_receiveBuffer, 0, _receiveBuffer.Length);
+                if (result == 0)
+                    return;
                 ReadHandler(_receiveBuffer, result);
             }
             catch (Exception ex)


### PR DESCRIPTION
connecting to the BNetServer without launcher cause the BNetServer to stuck in an infinite loop. The issue resolved by exiting the read loop
when read bytes are none (0).