### PR TITLE
Core/Transport: Fix GetPrevAnim methods (Prevent crash)

### DIFF
--- a/Source/Game/Maps/TransportManager.cs
+++ b/Source/Game/Maps/TransportManager.cs
@@ -689,7 +689,10 @@ namespace Game.Maps
 
             int reqIndex = Path.IndexOfKey(time);
             if (reqIndex != -1)
-                return Path.GetValueAtIndex(reqIndex - 1);
+            {
+                int prevIndex = (reqIndex < 1) ? 1 : (reqIndex - 1);
+                return Path.GetValueAtIndex(prevIndex);
+            }
 
             return Path.LastOrDefault().Value;
         }
@@ -701,7 +704,10 @@ namespace Game.Maps
 
             int reqIndex = Rotations.IndexOfKey(time);
             if (reqIndex != -1)
-                return Rotations.GetValueAtIndex(reqIndex - 1);
+            {
+                int prevIndex = (reqIndex < 1) ? 1 : (reqIndex - 1);
+                return Rotations.GetValueAtIndex(prevIndex);
+            }
 
             return Rotations.LastOrDefault().Value;
         }


### PR DESCRIPTION
Implement `C++ std:prev:`

> decrement an iterator by a given distance **or to a bound**

Prevent crash at [0] - index