### PR TITLE
Core/Realm: Fix setting realm NormalizedName

### DIFF
--- a/Source/Framework/Realm/Realm.cs
+++ b/Source/Framework/Realm/Realm.cs
@@ -12,8 +12,7 @@ public class Realm : IEquatable<Realm>
     public void SetName(string name)
     {
         Name = name;
-        NormalizedName = name;
-        NormalizedName = NormalizedName.Replace(" ", "");
+        NormalizedName = name.Replace(" ", "");
     }
 
     public IPAddress GetAddressForClient(IPAddress clientAddr)
@@ -60,8 +59,8 @@ public class Realm : IEquatable<Realm>
     public uint Build;
     public List<IPAddress> Addresses = new();
     public ushort Port;
-    public string Name;
-    public string NormalizedName;
+    public string Name { get; private set; }
+    public string NormalizedName { get; private set; }
     public byte Type;
     public RealmFlags Flags;
     public byte Timezone;

--- a/Source/Framework/Realm/RealmManager.cs
+++ b/Source/Framework/Realm/RealmManager.cs
@@ -96,7 +96,7 @@ public class RealmManager : Singleton<RealmManager>
             {
                 var realm = new Realm();
                 uint realmId = result.Read<uint>(0);
-                realm.Name = result.Read<string>(1);
+                realm.SetName(result.Read<string>(1));
                 realm.Addresses.Add(IPAddress.Parse(result.Read<string>(2)));
                 realm.Addresses.Add(IPAddress.Parse(result.Read<string>(3)));
                 realm.Port = result.Read<ushort>(4);


### PR DESCRIPTION
- This error was the reason for blocking the functions of the client's graphical interface (for example, the operation of the "Group Invite" key in the guild interface)