### PR TITLE
Core/Guild: Prevent invalid transactions from being sent to the SQL queue.

### DIFF
--- a/Source/Game/Guilds/Guild.cs
+++ b/Source/Game/Guilds/Guild.cs
@@ -1876,7 +1876,6 @@ namespace Game.Guilds
 
             info.CreateMissingTabsIfNeeded(_GetPurchasedTabsSize(), trans);
             info.SaveToDB(trans);
-            DB.Characters.CommitTransaction(trans);
 
             if (!isInTransaction)
                 DB.Characters.CommitTransaction(trans);


### PR DESCRIPTION
- this caused hidden data corruption in the database when creating a new guild